### PR TITLE
allow single provider names for authorization urls

### DIFF
--- a/src/Calendar/Calendar.php
+++ b/src/Calendar/Calendar.php
@@ -108,6 +108,10 @@ final class Calendar
             $postFields['reminders_create_only'] = $params['reminders_create_only'];
         }
 
+        if (!empty($params['event_private'])) {
+            $postFields['event_private'] = $params['event_private'];
+        }
+
         if (!empty($params['transparency'])) {
             $postFields['transparency'] = $params['transparency'];
         }

--- a/src/Token.php
+++ b/src/Token.php
@@ -123,14 +123,21 @@ class Token implements TokenInterface
     {
         $scope_list = rawurlencode(join(" ", $params['scope']));
         $url = $this->connection->getAppRootUrl() . '/oauth/authorize?response_type=code&client_id=' . $this->connection->getClientId() . '&redirect_uri=' . urlencode($params['redirect_uri']) . '&scope=' . $scope_list;
+
         if (!empty($params['state'])) {
             $url .= '&state=' . $params['state'];
         }
+
         if (!empty($params['avoid_linking'])) {
             $url .= '&avoid_linking=' . $params['avoid_linking'];
         }
+
         if (!empty($params['link_token'])) {
             $url.= '&link_token=' . $params['link_token'];
+        }
+
+        if (isset($params['provider_name'])) {
+            $url .= '&provider_name=' . $params['provider_name'];
         }
 
         return $url;


### PR DESCRIPTION
1. Allow single providers to sync to 
2. Add private events when pushing events to cronofy